### PR TITLE
Fix audio resampler argument bug

### DIFF
--- a/discord-bot/pkg/audio/convert.go
+++ b/discord-bot/pkg/audio/convert.go
@@ -109,7 +109,7 @@ func Resample(input *AudioInput, output *AudioOutput) error {
 		allArgs = append(allArgs, "-f", strings.ToLower(input.Format.String()))
 	}
 	if (input.Format == F32le || input.Format == S16le) && !input.NoArgs {
-		allArgs = append(allArgs, "-ac", stringify(input.Channels), "-ar", stringify(input.Channels))
+		allArgs = append(allArgs, "-ac", stringify(input.Channels), "-ar", stringify(input.SampleRate))
 	}
 	allArgs = append(allArgs, "-i", "pipe:")
 	allArgs = append(allArgs, outArgs...)


### PR DESCRIPTION
## Summary
- fix sample rate argument in ffmpeg call

## Testing
- `go test ./...` *(fails: replacement directory for whisper.cpp bindings does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68401e955a64832fae3043da6bd8a06b