### PR TITLE
Fix typo in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ With the power of __GPT__ and __Discord Bots__ you can truly let your pen & pape
 
 You can setup NPCs by giving them a script they should follow and a voice they should use while speaking.
 Once you add the Discord Bot to your voice channel it will automatically begin transcribing all of the conversation and storing it in a database as "memory" of the AI.
-Then the NPC will seemlessly integrate into the conversation and talk either once it seems fit or if it is addressed directly.
+Then the NPC will seamlessly integrate into the conversation and talk either once it seems fit or if it is addressed directly.


### PR DESCRIPTION
## Summary
- fix a typo in README description line

## Testing
- `grep -n seamlessly README.md`

------
https://chatgpt.com/codex/tasks/task_e_68401fbec34c832fae9c1ce2fd175232