### PR TITLE
Fix comment for S16le format

### DIFF
--- a/discord-bot/pkg/audio/convert.go
+++ b/discord-bot/pkg/audio/convert.go
@@ -26,8 +26,8 @@ const (
 	Opus AudioFormat = iota
 	// F32le is a 32bit floating point slice with little endianess (like []float32).
 	F32le
-	// S16le is a 316bit signed integer slice with little endianess (like []uint16).
-	S16le
+       // S16le is a 16bit signed integer slice.
+       S16le
 	// Wav file format.
 	Wav
 	// Mp3 file format.


### PR DESCRIPTION
## Summary
- correct the description for `S16le` audio format

## Testing
- `go test ./...` *(fails: replacement directory ./third_party/whisper.cpp/bindings/go does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68401fcf936c832f875e7b7fbfe29699